### PR TITLE
Add another route for upload (#1)

### DIFF
--- a/src/grav/routes.py
+++ b/src/grav/routes.py
@@ -50,6 +50,11 @@ def configure_routes(
             methods=doc_wk_methods,
         ),
         Route(
+            "/dw/{dw}/v/{v}/uploads",
+            scan_forward_doc_worker,
+            methods=doc_wk_methods,
+        ),
+        Route(
             "/o/{org}/api/docs/{docid}/attachments",
             scan_forward_home_worker,
             methods=home_wk_methods,


### PR DESCRIPTION
Fixes #1 

Add `/dw/{dw}/v/{v}/uploads`. 

This patch has not been tested.

NB: I don't know if we could not just use `/dw/{rest:path}/uploads` as suggested ([documentation here](https://www.starlette.io/routing/)). Same for the `/attachment` route.