### PR TITLE
Better handle the case when the AV scanning API is still scanning

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+export GRAV_SYNDETECT_API_URL=https://syndetect1.jecliqueoupas.cyber.gouv.fr/api/v1
+export GRAV_SYNDETECT_API_TOKEN=changeme
+
+export GRAV_FORWARD_DOC_WORKER_ORIGIN=http://testforward
+export GRAV_FORWARD_HOME_WORKER_ORIGIN=http://testforward
+export GRAV_LOG_LEVEL=DEBUG

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 A proxy for Grist handling antivirus scans using [Je clique ou pas ?](https://jecliqueoupas.cyber.gouv.fr/accueil). Meant to be used on Kubernetes with nginx-ingress.
 
+## Local dev setup
+
+To test locally with the live API you can use the provided `docker-compose.yml`.
+
+```bash
+cp .env.sample .env
+# then adjust .env to your needs
+
+# build and start the service
+# along with a basic server that listens for forwarded requests
+docker compose up --build -d
+
+# create test file to upload
+dd if=/dev/random of=/tmp/random.1k bs=1024 count=1
+# post file with curl
+curl -X POST -F 'upload=@/tmp/random.1k' localhost:8080/dw/dw/v/v/uploads
+# check the logs for grav and for the forwarded service
+docker compose logs grav
+docker compose logs testforward
+```
+
 ## Testing integration locally
 
 Set up a minikube node with KVM and mount the project directory on the node.

--- a/dev/Dockerfile.testforward
+++ b/dev/Dockerfile.testforward
@@ -1,0 +1,13 @@
+FROM python:3-alpine
+
+WORKDIR /app
+
+RUN pip install starlette uvicorn
+
+COPY testforward.py .
+
+ENV UVICORN_PORT=80
+ENV UVICORN_HOST=0.0.0.0
+
+ENTRYPOINT [ "uvicorn","testforward:app" ]
+

--- a/dev/testforward.py
+++ b/dev/testforward.py
@@ -1,0 +1,12 @@
+from starlette.applications import Starlette
+
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+
+async def endpoint(request):
+    print(f"got forwarded request for {request.path_params['path']}")
+    return JSONResponse({})
+
+
+app = Starlette(routes=[Route("/{path:path}", endpoint,methods=["POST"])])

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  grav:
+    build: .
+    ports:
+      - "127.0.0.1:8080:80"
+    env_file: .env
+  testforward:
+    build:
+      dockerfile: Dockerfile.testforward
+      context: dev/


### PR DESCRIPTION
Previously: 

First file scanning would try 10 times, with 1 to 5 seconds between each request.
If the file still didn't finish scanning and the user retried, the second file scanning would fail immediatly.

Now:

First file scanning will try 10 times, with 1 to 5 seconds between each request.
If the file still didn't finish scanning and the user retries, the second file scanning will retry every 5 seconds.

This should be a slightly better UX until we can get the file scanning API to respond more quickly.