### PR TITLE
Fix oomkill large files

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ["main"]
+    branches: ["*"]
     tags: ["*"]
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.

--- a/dev/Dockerfile.testsyndetect
+++ b/dev/Dockerfile.testsyndetect
@@ -1,0 +1,13 @@
+FROM python:3-alpine
+
+WORKDIR /app
+
+RUN pip install starlette uvicorn
+
+COPY testsyndetect.py .
+
+ENV UVICORN_PORT=80
+ENV UVICORN_HOST=0.0.0.0
+
+ENTRYPOINT [ "uvicorn","testsyndetect:app" ]
+

--- a/dev/testsyndetect.py
+++ b/dev/testsyndetect.py
@@ -1,0 +1,36 @@
+from starlette.applications import Starlette
+
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+iteration = 0
+
+
+async def results(request):
+    print(f"got result request for {request.path_params['path']}")
+    global iteration
+    iteration += 1
+    if iteration % 2 == 1:
+        # return waiting
+        return JSONResponse({}, status_code=404)
+    else:
+        # return result
+        return JSONResponse({"done": True, "is_malware": False})
+
+async def submit(request):
+    print(f"got submit request for {request.path_params['path']}")
+    return JSONResponse({})
+
+app = Starlette(
+    routes=[
+        Route(
+            "/results/{path:path}",
+            results,
+            methods=["GET"],
+        ),
+        Route(
+            "/submit/{path:path}",
+submit,methods=["POST"]
+        ),
+    ]
+)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,3 +9,7 @@ services:
     build:
       dockerfile: Dockerfile.testforward
       context: dev/
+  testsyndetect:
+    build:
+      dockerfile: Dockerfile.testsyndetect
+      context: dev/

--- a/src/grav/av_scanner/syndetect.py
+++ b/src/grav/av_scanner/syndetect.py
@@ -28,6 +28,7 @@ class SyndetectAVScanner(BaseAVScanner):
         self._CLIENT = httpx.AsyncClient(
             base_url=self._API_URL,
             headers={"X-Auth-token": self._API_TOKEN},
+            timeout=None,
         )
 
         self._MAX_POLL_TIME = max_poll_time

--- a/src/grav/forwarder/base.py
+++ b/src/grav/forwarder/base.py
@@ -6,5 +6,5 @@ from starlette.responses import Response
 
 class BaseForwarder(ABC):
     @abstractmethod
-    async def forward(self, request: Request) -> Response:
+    async def forward(self, request: Request, file = None) -> Response:
         pass

--- a/src/grav/forwarder/httpx.py
+++ b/src/grav/forwarder/httpx.py
@@ -13,7 +13,9 @@ class HttpxForwarder(BaseForwarder):
     def __init__(self, new_origin: ParseResult) -> None:
         super().__init__()
         self._NEW_ORIGIN = new_origin
-        self._CLIENT = httpx.AsyncClient()
+        self._CLIENT = httpx.AsyncClient(
+            timeout=None,
+        )
 
     async def forward(
         self, request: Request, fileinfo: tuple[str, BinaryIO, str] = None

--- a/src/grav/forwarder/httpx.py
+++ b/src/grav/forwarder/httpx.py
@@ -2,6 +2,7 @@ import logging
 from urllib.parse import urlparse, ParseResult
 
 import httpx
+from typing import BinaryIO
 
 from .base import BaseForwarder, Request, Response
 
@@ -14,7 +15,9 @@ class HttpxForwarder(BaseForwarder):
         self._NEW_ORIGIN = new_origin
         self._CLIENT = httpx.AsyncClient()
 
-    async def forward(self, request: Request) -> Response:
+    async def forward(
+        self, request: Request, fileinfo: tuple[str, BinaryIO, str] = None
+    ) -> Response:
         logger.info(f"forwarding request to {self._NEW_ORIGIN.geturl()}")
         old_url = urlparse(str(request.url))
         new_url = old_url._replace(
@@ -27,7 +30,7 @@ class HttpxForwarder(BaseForwarder):
             new_url.geturl(),
             headers=request.headers,
             params=request.query_params,
-            content=await request.body(),
+            files={"upload": fileinfo} if fileinfo else None,
         )
         logger.debug(f"request headers {request.headers}")
         logger.debug(f"forwarded headers {fwd_request.headers}")

--- a/src/grav/routes.py
+++ b/src/grav/routes.py
@@ -11,9 +11,6 @@ logger = logging.getLogger(__name__)
 
 async def endpoint_scan(request, av_scanner: BaseAVScanner, forwarder: BaseForwarder):
     if request.method == "POST":
-        # awaiting body() before form() ensures we can still read the body later on
-        # but maybe this has resource usage implications, we may need to manually save the body in a spooled temp file
-        await request.body()
         async with request.form() as form:
             upload = form.get("upload")
             if upload is None:
@@ -22,7 +19,7 @@ async def endpoint_scan(request, av_scanner: BaseAVScanner, forwarder: BaseForwa
             result = await av_scanner.process(upload.file)
             if result == AVScanResult.SAFE:
                 logger.info("scanner determined that the file is safe, forwarding")
-                return await forwarder.forward(request)
+                return await forwarder.forward(request, (upload.filename, upload.file, upload.content_type))
             elif result == AVScanResult.MALWARE:
                 logger.info("scanner determined that the file is malware, blocking")
                 return JSONResponse({"error": "malware file"}, status_code=400)

--- a/src/grav/routes.py
+++ b/src/grav/routes.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 async def endpoint_scan(request, av_scanner: BaseAVScanner, forwarder: BaseForwarder):
     if request.method == "POST":
+        logger.info("received POST request, processing")
         async with request.form() as form:
             upload = form.get("upload")
             if upload is None:
@@ -27,6 +28,7 @@ async def endpoint_scan(request, av_scanner: BaseAVScanner, forwarder: BaseForwa
                 logger.info("failed to complete AV test")
                 return JSONResponse({"error": "failed AV test"}, status_code=502)
     else:
+        logger.info(f"received {request.method} request, forwarding as-is")
         return await forwarder.forward(request)
 
 


### PR DESCRIPTION
Try to pass the file descriptor directly instead of reading body in memory

Adds some bits to the local test setup too

Can be tagged as 1.2.2 once merged